### PR TITLE
MainUI improvements + sync with upstream

### DIFF
--- a/WindowSystem.cpp
+++ b/WindowSystem.cpp
@@ -266,7 +266,7 @@ void CWindowStack::Remove( CMenuBaseWindow *menu )
 
 	if( idx == stack.InvalidIndex() )
 	{
-		Con_DPrintf( "CWindowStack::Remove: can't remove not opened window" );
+		Con_DPrintf( "CWindowStack::Remove: can't remove not opened window\n" );
 	}
 
 	if( this == &uiStatic.menu ) // hack!

--- a/menus/Crosshair.cpp
+++ b/menus/Crosshair.cpp
@@ -116,6 +116,7 @@ public:
 	CMenuCheckBox useXhair;
 	CMenuClassicCrosshair crosshair;
 	CMenuXhair xhair;
+	CMenuPicButton cancel;
 	CMenuPicButton done;
 
 private:
@@ -158,16 +159,22 @@ void CMenuCrosshair::_Init()
 	crosshair.SetRect( 72, 350, 880, 466 );
 	xhair.SetRect( 72, 350, 880, 466 );
 
+	cancel.szName = L( "GameUI_Cancel" );
+	cancel.SetCoord( 72, 280 );
+	cancel.SetPicture( PC_CANCEL );
+	cancel.onReleased = VoidCb( &CMenuCrosshair::Hide );
+
+	done.szName = L( "GameUI_OK" );
+	done.SetCoord( 222, 280 );
+	done.SetPicture( PC_DONE );
+	done.onReleased = VoidCb( &CMenuCrosshair::SaveAndPopMenu );
+
 	AddItem( banner );
 	AddItem( useXhair );
 	AddItem( crosshair );
 	AddItem( xhair );
+	AddItem( cancel );
 	AddItem( done );
-
-	done.szName = L( "GameUI_OK" );
-	done.SetCoord( 72, 280 );
-	done.SetPicture( PC_DONE );
-	done.onReleased = VoidCb( &CMenuCrosshair::SaveAndPopMenu );
 
 	ToggleMenu();
 }

--- a/menus/PlayerSetup.cpp
+++ b/menus/PlayerSetup.cpp
@@ -573,24 +573,24 @@ void CMenuPlayerSetup::_Init( void )
 	showModels.szName = L( "Show 3D preview" );
 	showModels.onCvarChange = CMenuEditable::WriteCvarCb;
 	showModels.LinkCvar( "ui_showmodels" );
-	showModels.SetCoord( 77, 230 + m_iBtnsNum * 50 + 10 );
+	showModels.SetCoord( 77, 230 + m_iBtnsNum * 50 + 5 );
 
 	hiModels.iFlags |= addFlags;
 	hiModels.szName = L( "GameUI_HighModels" );
 	hiModels.onCvarChange = CMenuEditable::WriteCvarCb;
 	hiModels.LinkCvar( "cl_himodels" );
-	hiModels.SetCoord( 77, showModels.pos.y + 50 );
+	hiModels.SetCoord( 77, showModels.pos.y + 45 );
 
 	voiceEnable.szName = L( "GameUI_EnableVoice" );
 	voiceEnable.onCvarChange = CMenuEditable::WriteCvarCb;
 	voiceEnable.LinkCvar( "voice_modenable" ); // unlike engine's voice_enable, this is synchronized with server
-	voiceEnable.SetCoord( 77, hiModels.pos.y + 50 );
+	voiceEnable.SetCoord( 77, hiModels.pos.y + 45 );
 
 	transmitVolume.szName = L( "GameUI_VoiceTransmitVolume" );
 	transmitVolume.onCvarChange = CMenuEditable::WriteCvarCb;
 	transmitVolume.Setup( 0, 1, 0.05f );
 	transmitVolume.LinkCvar( "voice_transmit_scale" );
-	transmitVolume.SetCoord( 77, voiceEnable.pos.y + 100 );
+	transmitVolume.SetCoord( 77, voiceEnable.pos.y + 75 );
 	transmitVolume.size.w = 300;
 
 	receiveVolume.szName = L( "GameUI_VoiceReceiveVolume" );
@@ -603,7 +603,7 @@ void CMenuPlayerSetup::_Init( void )
 	noProprietaryCodecNotice.szName = L( "* Uses Opus Codec.\nOpen, royalty-free, highly versatile audio codec." );
 	noProprietaryCodecNotice.colorBase = uiColorHelp;
 	noProprietaryCodecNotice.SetCharSize( QM_SMALLFONT );
-	noProprietaryCodecNotice.SetRect( 77, receiveVolume.pos.y + 30, 400, 100 );
+	noProprietaryCodecNotice.SetRect( 77, receiveVolume.pos.y + 20, 400, 100 );
 
 	if( !hideLogos )
 	{

--- a/menus/TouchButtons.cpp
+++ b/menus/TouchButtons.cpp
@@ -90,6 +90,8 @@ public:
 	class CMenuButtonPreview : public CMenuBaseItem
 	{
 	public:
+		CMenuButtonPreview() : CMenuBaseItem(), textureId( 0 ) { }
+
 		void Draw() override;
 		HIMAGE textureId;
 	} preview;


### PR DESCRIPTION
**Fixed Opus codec notice extending beyond the screen edges.**
**Added a Cancel button to the Crosshair menu for discarding changes.**
### Before
<img width="1920" height="1080" alt="Снимок экрана (23)" src="https://github.com/user-attachments/assets/9093c37c-62d0-4267-a2b6-ff67e4b924b3" />

### After
<img width="1920" height="1080" alt="Снимок экрана (21)" src="https://github.com/user-attachments/assets/25ea5876-6b31-49a5-9c45-c3859e16e40d" />

### Crosshair Menu
<img width="1920" height="1080" alt="Снимок экрана (22)" src="https://github.com/user-attachments/assets/8bbd36d7-78fc-49b9-be9d-510d3ca84fc7" />
