### PR TITLE
SpinControl: allow direct keyboard entry for numeric controls

### DIFF
--- a/controls/SpinControl.cpp
+++ b/controls/SpinControl.cpp
@@ -23,7 +23,7 @@ GNU General Public License for more details.
 CMenuSpinControl::CMenuSpinControl()  : BaseClass(), m_szBackground(),
 		m_szLeftArrow(), m_szRightArrow(), m_szLeftArrowFocus(), m_szRightArrowFocus(),
 		m_flMinValue(0), m_flMaxValue(1), m_flCurValue(0), m_flRange(0.1), m_pModel( NULL ),
-		m_iFloatPrecision(0)
+		m_iFloatPrecision(0), m_bEditing(false)
 {
 	m_szBackground = 0;
 	m_szLeftArrow = UI_LEFTARROW;
@@ -31,6 +31,7 @@ CMenuSpinControl::CMenuSpinControl()  : BaseClass(), m_szBackground(),
 	m_szRightArrow = UI_RIGHTARROW;
 	m_szRightArrowFocus = UI_RIGHTARROWFOCUS;
 	m_szDisplay[0] = 0;
+	m_szEdit[0] = 0;
 
 	eTextAlignment = QM_CENTER;
 	eFocusAnimation = QM_HIGHLIGHTIFFOCUS;
@@ -53,6 +54,35 @@ bool CMenuSpinControl::KeyDown( int key )
 {
 	const char *sound = 0;
 
+	// Direct numeric entry for numeric spin controls (not list/model based).
+	// This mirrors CMenuField: while focused the value is the live edit buffer, so
+	// the caret is shown, typing appends and backspace deletes the last digit.
+	if( !m_pModel && m_bEditing && !FBitSet( iFlags, QMF_MOUSEONLY ))
+	{
+		if( UI::Key::IsBackspace( key ))
+		{
+			int len = (int)strlen( m_szEdit );
+			if( len > 0 )
+				m_szEdit[len - 1] = 0;
+			Q_strncpy( m_szDisplay, m_szEdit, sizeof( m_szDisplay ));
+			SyncValueFromEdit();
+			PlayLocalSound( uiStatic.sounds[SND_MOVE] );
+			return true;
+		}
+
+		if( UI::Key::IsEnter( key ))
+		{
+			SyncValueFromEdit(); // commit typed value (clamped)
+			SyncEditFromValue(); // canonicalize the buffer/display, stay editing
+			PlayLocalSound( uiStatic.sounds[SND_MOVE] );
+			return true; // consume so Enter doesn't trigger the default action
+		}
+
+		// an arrow first commits whatever is typed, then nudges
+		if( UI::Key::IsLeftArrow( key ) || UI::Key::IsRightArrow( key ))
+			SyncValueFromEdit();
+	}
+
 	if( UI::Key::IsLeftArrow( key ) && !FBitSet( iFlags, QMF_MOUSEONLY ))
 		sound = MoveLeft();
 	else if( UI::Key::IsRightArrow( key ) && !FBitSet( iFlags, QMF_MOUSEONLY ))
@@ -67,8 +97,86 @@ bool CMenuSpinControl::KeyDown( int key )
 			_Event( QM_CHANGED );
 		}
 		PlayLocalSound( sound );
+
+		// keep the edit buffer in sync with the value the arrows produced
+		if( !m_pModel && m_bEditing )
+			SyncEditFromValue();
 	}
 	return sound != NULL;
+}
+
+void CMenuSpinControl::Char( int key )
+{
+	if( m_pModel || !m_bEditing ) // only numeric spin controls accept typing
+		return;
+
+	bool accept = false;
+	if( key >= '0' && key <= '9' )
+		accept = true;
+	else if( key == '.' && m_iFloatPrecision > 0 && !strchr( m_szEdit, '.' ))
+		accept = true;
+	else if( key == '-' && m_flMinValue < 0 && m_szEdit[0] == 0 )
+		accept = true;
+
+	if( !accept )
+		return;
+
+	int len = (int)strlen( m_szEdit );
+	if( len >= (int)sizeof( m_szEdit ) - 1 )
+		return;
+
+	// append at the end (the caret is drawn after the value)
+	m_szEdit[len] = (char)key;
+	m_szEdit[len + 1] = 0;
+	Q_strncpy( m_szDisplay, m_szEdit, sizeof( m_szDisplay ));
+	SyncValueFromEdit();
+}
+
+void CMenuSpinControl::_Event( int ev )
+{
+	switch( ev )
+	{
+	case QM_GOTFOCUS:
+		if( !m_pModel )
+		{
+			UI_EnableTextInput( true );
+			m_bEditing = true;
+			SyncEditFromValue(); // seed the buffer so the value is editable + caret shown
+		}
+		break;
+	case QM_LOSTFOCUS:
+		if( m_bEditing )
+		{
+			SyncValueFromEdit(); // commit typed value (clamped)
+			m_bEditing = false;
+			Display();           // show the final, canonical value
+		}
+		if( !m_pModel )
+			UI_EnableTextInput( false );
+		break;
+	}
+
+	BaseClass::_Event( ev );
+}
+
+void CMenuSpinControl::SyncEditFromValue()
+{
+	snprintf( m_szEdit, sizeof( m_szEdit ), "%.*f", m_iFloatPrecision, m_flCurValue );
+	Q_strncpy( m_szDisplay, m_szEdit, sizeof( m_szDisplay ));
+}
+
+void CMenuSpinControl::SyncValueFromEdit()
+{
+	float v = (float)atof( m_szEdit );
+
+	if( v < m_flMinValue ) v = m_flMinValue;
+	if( v > m_flMaxValue ) v = m_flMaxValue;
+
+	bool notify = ( m_flCurValue != v );
+	m_flCurValue = v;
+	SetCvarValue( v ); // update value/cvar without reformatting the typed display
+	if( notify )
+		_Event( QM_CHANGED );
 }
 
 /*
@@ -84,6 +192,10 @@ bool CMenuSpinControl::KeyUp( int key )
 
 	if( UI::Key::IsLeftMouse( key ) && FBitSet( iFlags, QMF_HASMOUSEFOCUS ))
 	{
+		// clicking an arrow commits any typed value first, then nudges
+		if( !m_pModel && m_bEditing )
+			SyncValueFromEdit();
+
 		// calculate size and position for the arrows
 		arrow.w = m_scSize.h + UI_OUTLINE_WIDTH * 2 * uiStatic.scaleX;
 		arrow.h = m_scSize.h + UI_OUTLINE_WIDTH * 2 * uiStatic.scaleY;
@@ -109,6 +221,10 @@ bool CMenuSpinControl::KeyUp( int key )
 			_Event( QM_CHANGED );
 		}
 		PlayLocalSound( sound );
+
+		// keep the edit buffer in sync with the value the arrows produced
+		if( !m_pModel && m_bEditing )
+			SyncEditFromValue();
 	}
 	return sound != NULL;
 }
@@ -217,6 +333,27 @@ void CMenuSpinControl::Draw( void )
 		UI_DrawPic( left, arrow, (leftFocus) ? color : (int)colorBase, (leftFocus) ? m_szLeftArrowFocus : m_szLeftArrow );
 		UI_DrawPic( right, arrow, (rightFocus) ? color : (int)colorBase, (rightFocus) ? m_szRightArrowFocus : m_szRightArrow );
 	}
+
+	// Numeric spinners edit like text fields: show a blinking caret whenever focused
+	// (m_bEditing is set on focus). Gated to numeric mode so list spinners are unaffected.
+	if( !m_pModel && m_bEditing && ( uiStatic.realTime & 499 ) < 250 )
+	{
+		const char *cursor_char = "_";
+		int textW  = g_FontMgr->GetTextWideScaled( font, m_szDisplay, m_scChSize );
+		int caretW = g_FontMgr->GetTextWideScaled( font, cursor_char, m_scChSize );
+		int caretX;
+
+		if( eTextAlignment & QM_LEFT )
+			caretX = scCenterPos.x + textW;
+		else if( eTextAlignment & QM_RIGHT )
+			caretX = scCenterPos.x + scCenterBox.w - caretW;
+		else // QM_CENTER
+			caretX = scCenterPos.x + ( scCenterBox.w + textW ) / 2;
+
+		UI::Scissor::PushScissor( scCenterPos, scCenterBox );
+		UI_DrawString( font, caretX, m_scPos.y, caretW, m_scSize.h, cursor_char, colorFocus, m_scChSize, QM_LEFT, textflags | ETF_FORCECOL );
+		UI::Scissor::PopScissor();
+	}
 }
 
 const char *CMenuSpinControl::MoveLeft()
@@ -253,6 +390,9 @@ const char *CMenuSpinControl::MoveRight()
 
 void CMenuSpinControl::UpdateEditable()
 {
+	if( m_bEditing ) // don't clobber a value the user is typing
+		return;
+
 	switch( m_eType )
 	{
 	case CVAR_STRING:

--- a/controls/SpinControl.h
+++ b/controls/SpinControl.h
@@ -30,6 +30,8 @@ public:
 	void VidInit( void ) override;
 	bool KeyUp( int key ) override;
 	bool KeyDown( int key ) override;
+	void Char( int key ) override;
+	void _Event( int ev ) override;
 	void Draw( void ) override;
 	void UpdateEditable() override;
 
@@ -50,6 +52,8 @@ private:
 	const char *MoveLeft();
 	const char *MoveRight();
 	void Display();
+	void SyncEditFromValue(); // refresh the edit buffer/display from the current value
+	void SyncValueFromEdit(); // parse the edit buffer into the value/cvar (clamped)
 
 	CImage m_szBackground;
 	CImage m_szLeftArrow;
@@ -65,6 +69,9 @@ private:
 	short m_iFloatPrecision;
 
 	char m_szDisplay[CS_SIZE];
+
+	bool m_bEditing;          // user is typing a value directly
+	char m_szEdit[CS_SIZE];   // in-progress typed text (numeric mode only)
 };
 
 #endif // MENU_SPINCONTROL_H


### PR DESCRIPTION
## Problem

Numeric `CMenuSpinControl` values can only be changed with the `+`/`-` arrows, one `Setup()` step at a time. For controls with a large range this is impractical — e.g. `mp_startmoney` (**800–16000**) on the *Create Game → Advanced* screen would take thousands of clicks/keypresses to reach the maximum.

## Change

Let numeric spin controls (those **without** a list model, `m_pModel == NULL`) be edited directly, like a `CMenuField`:

- On focus the current value becomes an editable buffer and a **blinking caret** is shown (matching the caret `CMenuField` draws), signalling the field is typeable.
- **Typing appends** digits. `.` is accepted when the control has decimal precision (`m_iFloatPrecision > 0`), and a leading `-` when the range allows negatives.
- **Backspace** deletes the last character.
- **Enter**, an **arrow** (keyboard or mouse-clicked), or **losing focus** commits the typed value, **clamped** to the control's `min`/`max`. The arrows keep working and re-sync the edit buffer.

Everything is gated to numeric mode, so **list/enum spin controls are unaffected** (no caret, no typing) and keep their existing behaviour.

## Implementation notes

- `Char()` and `_Event()` are now overridden; `QM_GOTFOCUS`/`QM_LOSTFOCUS` toggle `UI_EnableTextInput` and seed/commit the buffer.
- Two small helpers, `SyncEditFromValue()` / `SyncValueFromEdit()`, keep the display buffer and the value/cvar consistent.
- `UpdateEditable()` is guarded so an external cvar sync doesn't clobber a value the user is mid-typing.

## Testing

Built for macOS arm64 and used in-game: on *Create Game → Advanced*, `mp_startmoney` (and the other numeric fields: max players, round time, etc.) can now be typed directly (e.g. type `16000`, Enter), while the arrows still nudge by the configured step. Verified list-based spin controls (video/audio menus) are unchanged.

Targets the `cs16-client` branch (the branch cs16-client's submodule tracks).
