### PR TITLE
fix: route mouse wheel to hovered item

### DIFF
--- a/Utils.h
+++ b/Utils.h
@@ -296,6 +296,17 @@ inline bool IsMouse( int key )
 	return false;
 }
 
+inline bool IsMouseWheel( int key )
+{
+	switch( key )
+	{
+	case K_MWHEELUP:
+	case K_MWHEELDOWN:
+		return true;
+	}
+	return false;
+}
+
 inline bool IsUpArrow( int key )
 {
 	switch( key )

--- a/controls/ItemsHolder.cpp
+++ b/controls/ItemsHolder.cpp
@@ -36,6 +36,28 @@ bool CMenuItemsHolder::Key( const int key, const bool down )
 	if( !m_pItems.Count() )
 		return false;
 
+	if( UI::Key::IsMouseWheel( key ) )
+	{
+		FOR_EACH_VEC( m_pItems, i )
+		{
+			CMenuBaseItem *item = m_pItems[i];
+
+			if( !item || FBitSet( item->iFlags, QMF_GRAYED | QMF_INACTIVE ) )
+				continue;
+
+			if( !item->IsVisible() )
+				continue;
+
+			if( !UI_CursorInRect( item->m_scPos, item->m_scSize ) )
+				continue;
+
+			if( down ? item->KeyDown( key ) : item->KeyUp( key ) )
+				return true;
+		}
+
+		return false;
+	}
+
 	CMenuBaseItem *item = NULL;
 	int cursorPrev;
 


### PR DESCRIPTION
Fixes non-functional mouse wheel scrolling for the map description in the MainUI-based team selection menu.
See also: https://github.com/Velaron/cs16-client/pull/391